### PR TITLE
Prevent hanging on 'Loading...' without a saves folder in development

### DIFF
--- a/app/js/saves.js
+++ b/app/js/saves.js
@@ -8,7 +8,7 @@ let openedSaveFile;
 // Read save files from "saves" folder
 function readSaveFiles() {
     const updatedSaves = [];
-    const files = fs.readdirSync(savesFolder);
+    const files = fs.readdirSync(savesFolder).filter(file => /\.board$/.test(file));
 
     files.forEach(file => {
         const found = saves.find(save => save.fileName == file);


### PR DESCRIPTION
Hi, awesome project! I have never seen such a large, smooth Electron application being written in pure, frameworkless Javascript.

While looking around, I bumped into a non-existent saves folder when trying out BOOLR in development. This pull request adds the saves folder (with a .gitkeep file), and excludes any files without the .board extension to be read as a save file (because otherwise the .gitkeep file would show up). 

That might not be the best solution, but as the directory is assumed to be existent in multiple places, I thought I'd leave it at this.