### PR TITLE
Fix wire bugs

### DIFF
--- a/app/js/canvas.js
+++ b/app/js/canvas.js
@@ -343,13 +343,6 @@ c.onmousedown = function(e) {
                     } else {
                         component.update();
                     }
-                } else if(found = findWireByPos()) {
-                    connecting = new Wire();
-                    connecting.input.push(found);
-                    connecting.pos.push({
-                        x: mouse.grid.x,
-                        y: mouse.grid.y
-                    });
                 } else if(found = findPortByPos()) {
                     const port = found;
                     if(port.type == "output") {
@@ -360,6 +353,13 @@ c.onmousedown = function(e) {
                             y: mouse.grid.y
                         });
                     }
+                } else if(found = findWireByPos()) {
+                    connecting = new Wire();
+                    connecting.input.push(found);
+                    connecting.pos.push({
+                        x: mouse.grid.x,
+                        y: mouse.grid.y
+                    });
                 } else {
                     const component = new Selected();
                     add(

--- a/app/js/canvas.js
+++ b/app/js/canvas.js
@@ -457,18 +457,26 @@ c.onmousedown = function(e) {
                     component.pos.y += dy / 2.5;
 
                     for(let i = 0; i < component.input.length; ++i) {
-                        const wire = component.input[i].connection;
-                        if(wire) {
-                            wire.pos.slice(-1)[0].x += dx / 2.5;
-                            wire.pos.slice(-1)[0].y += dy / 2.5;
+                        const cons = component.input[i].connection;
+                        if (cons) {
+                            for (let wire of cons) {
+                                if(wire) {
+                                    wire.pos.slice(-1)[0].x += dx / 2.5;
+                                    wire.pos.slice(-1)[0].y += dy / 2.5;
+                                }
+                            }
                         }
                     }
 
                     for(let i = 0; i < component.output.length; ++i) {
-                        const wire = component.output[i].connection;
-                        if(wire) {
-                            wire.pos[0].x += dx / 2.5;
-                            wire.pos[0].y += dy / 2.5;
+                        const cons = component.output[i].connection;
+                        if (cons) {
+                            for (let wire of cons) {
+                                if(wire) {
+                                    wire.pos[0].x += dx / 2.5;
+                                    wire.pos[0].y += dy / 2.5;
+                                }
+                            }
                         }
                     }
 
@@ -483,18 +491,26 @@ c.onmousedown = function(e) {
                         component.pos.y = Math.round(component.pos.y);
 
                         for(let i = 0; i < component.input.length; ++i) {
-                            const wire = component.input[i].connection;
-                            if(wire) {
-                                wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
-                                wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y)
+                            const cons = component.input[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire) {
+                                        wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
+                                        wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y)
+                                    }
+                                }
                             }
                         }
 
                         for(let i = 0; i < component.output.length; ++i) {
-                            const wire = component.output[i].connection;
-                            if(wire) {
-                                wire.pos[0].x = Math.round(wire.pos[0].x);
-                                wire.pos[0].y = Math.round(wire.pos[0].y)
+                            const cons = component.output[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire) {
+                                        wire.pos[0].x = Math.round(wire.pos[0].x);
+                                        wire.pos[0].y = Math.round(wire.pos[0].y)
+                                    }
+                                }
                             }
                         }
 
@@ -555,18 +571,26 @@ c.onmousemove = function(e) {
                     component.pos.y += dy;
 
                     for(let i = 0; i < component.input.length; ++i) {
-                        const wire = component.input[i].connection
-                        if(wire && !wires.includes(wire)) {
-                            wire.pos.slice(-1)[0].x += dx;
-                            wire.pos.slice(-1)[0].y += dy;
+                        const cons = component.input[i].connection;
+                        if (cons) {
+                            for (let wire of cons) {
+                                if(wire && !wires.includes(wire)) {
+                                    wire.pos.slice(-1)[0].x += dx;
+                                    wire.pos.slice(-1)[0].y += dy;
+                                }
+                            }
                         }
                     }
 
                     for(let i = 0; i < component.output.length; ++i) {
-                        const wire = component.output[i].connection
-                        if(wire && !wires.includes(wire)) {
-                            wire.pos[0].x += dx;
-                            wire.pos[0].y += dy;
+                        const cons = component.output[i].connection;
+                        if (cons) {
+                            for (let wire of cons) {
+                                if(wire && !wires.includes(wire)) {
+                                    wire.pos[0].x += dx;
+                                    wire.pos[0].y += dy;
+                                }
+                            }
                         }
                     }
                 }
@@ -600,18 +624,26 @@ c.onmousemove = function(e) {
 
                 // Then, all the wires to and from the component need to be fixed...
                 for(let i = 0; i < component.input.length; ++i) {
-                    const wire = component.input[i].connection;
-                    if(wire) {
-                        wire.pos.slice(-1)[0].x += dx;
-                        wire.pos.slice(-1)[0].y += dy;
+                    const cons = component.input[i].connection;
+                    if (cons) {
+                        for (let wire of cons) {
+                            if(wire) {
+                                wire.pos.slice(-1)[0].x += dx;
+                                wire.pos.slice(-1)[0].y += dy;
+                            }
+                        }
                     }
                 }
 
                 for(let i = 0; i < component.output.length; ++i) {
-                    const wire = component.output[i].connection;
-                    if(wire) {
-                        wire.pos[0].x += dx;
-                        wire.pos[0].y += dy;
+                    const cons = component.output[i].connection;
+                    if (cons) {
+                        for (let wire of cons) {
+                            if(wire) {
+                                wire.pos[0].x += dx;
+                                wire.pos[0].y += dy;
+                            }
+                        }
                     }
                 }
             } else if(dragging.port) {
@@ -652,12 +684,14 @@ c.onmousemove = function(e) {
                     if(pos.side % 2 == 0) gridPos.x += pos.pos;
                     else gridPos.y -= pos.pos;
 
-                    if(port.type == "input") {
-                        port.connection.pos.slice(-1)[0].x = gridPos.x;
-                        port.connection.pos.slice(-1)[0].y = gridPos.y;
-                    } else {
-                        port.connection.pos[0].x = gridPos.x;
-                        port.connection.pos[0].y = gridPos.y;
+                    for (let wire of port.connection) {
+                        if(port.type == "input") {
+                            wire.pos.slice(-1)[0].x = gridPos.x;
+                            wire.pos.slice(-1)[0].y = gridPos.y;
+                        } else {
+                            wire.pos[0].x = gridPos.x;
+                            wire.pos[0].y = gridPos.y;
+                        }
                     }
                 }
             }
@@ -847,18 +881,26 @@ c.onmouseup = function(e) {
                         component.pos.y += dy / 2.5;
 
                         for(let i = 0; i < component.input.length; ++i) {
-                            const wire = component.input[i].connection
-                            if(wire && !wires.includes(wire)) {
-                                wire.pos.slice(-1)[0].x += dx / 2.5;
-                                wire.pos.slice(-1)[0].y += dy / 2.5;
+                            const cons = component.input[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire && !wires.includes(wire)) {
+                                        wire.pos.slice(-1)[0].x += dx / 2.5;
+                                        wire.pos.slice(-1)[0].y += dy / 2.5;
+                                    }
+                                }
                             }
                         }
 
                         for(let i = 0; i < component.output.length; ++i) {
-                            const wire = component.output[i].connection
-                            if(wire && !wires.includes(wire)) {
-                                wire.pos[0].x += dx / 2.5;
-                                wire.pos[0].y += dy / 2.5;
+                            const cons = component.output[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire && !wires.includes(wire)) {
+                                        wire.pos[0].x += dx / 2.5;
+                                        wire.pos[0].y += dy / 2.5;
+                                    }
+                                }
                             }
                         }
                     }
@@ -896,18 +938,26 @@ c.onmouseup = function(e) {
                             component.pos.y = Math.round(component.pos.y);
 
                             for(let i = 0; i < component.input.length; ++i) {
-                                const wire = component.input[i].connection
-                                if(wire && !wires.includes(wire)) {
-                                    wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
-                                    wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
+                                const cons = component.input[i].connection;
+                                if (cons) {
+                                    for (let wire of cons) {
+                                        if(wire && !wires.includes(wire)) {
+                                            wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
+                                            wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
+                                        }
+                                    }
                                 }
                             }
 
                             for(let i = 0; i < component.output.length; ++i) {
-                                const wire = component.output[i].connection
-                                if(wire && !wires.includes(wire)) {
-                                    wire.pos[0].x = Math.round(wire.pos[0].x);
-                                    wire.pos[0].y = Math.round(wire.pos[0].y);
+                                const cons = component.output[i].connection;
+                                if (cons) {
+                                    for (let wire of cons) {
+                                        if(wire && !wires.includes(wire)) {
+                                            wire.pos[0].x = Math.round(wire.pos[0].x);
+                                            wire.pos[0].y = Math.round(wire.pos[0].y);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -963,18 +1013,26 @@ c.onmouseup = function(e) {
                         component.pos.y += dy / 2.5;
 
                         for(let i = 0; i < component.input.length; ++i) {
-                            const wire = component.input[i].connection;
-                            if(wire) {
-                                wire.pos.slice(-1)[0].x += dx / 2.5;
-                                wire.pos.slice(-1)[0].y += dy / 2.5;
+                            const cons = component.input[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire) {
+                                        wire.pos.slice(-1)[0].x += dx / 2.5;
+                                        wire.pos.slice(-1)[0].y += dy / 2.5;
+                                    }
+                                }
                             }
                         }
 
                         for(let i = 0; i < component.output.length; ++i) {
-                            const wire = component.output[i].connection;
-                            if(wire) {
-                                wire.pos[0].x += dx / 2.5;
-                                wire.pos[0].y += dy / 2.5;
+                            const cons = component.output[i].connection;
+                            if (cons) {
+                                for (let wire of cons) {
+                                    if(wire) {
+                                        wire.pos[0].x += dx / 2.5;
+                                        wire.pos[0].y += dy / 2.5;
+                                    }
+                                }
                             }
                         }
 
@@ -989,18 +1047,26 @@ c.onmouseup = function(e) {
                             component.pos.y = Math.round(component.pos.y);
 
                             for(let i = 0; i < component.input.length; ++i) {
-                                const wire = component.input[i].connection;
-                                if(wire) {
-                                    wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
-                                    wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
+                                const cons = component.input[i].connection;
+                                if (cons) {
+                                    for (let wire of cons) {
+                                        if(wire) {
+                                            wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
+                                            wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
+                                        }
+                                    }
                                 }
                             }
 
                             for(let i = 0; i < component.output.length; ++i) {
-                                const wire = component.output[i].connection;
-                                if(wire) {
-                                    wire.pos[0].x = Math.round(wire.pos[0].x);
-                                    wire.pos[0].y = Math.round(wire.pos[0].y);
+                                const cons = component.output[i].connection;
+                                if (cons) {
+                                    for (let wire of cons) {
+                                        if(wire) {
+                                            wire.pos[0].x = Math.round(wire.pos[0].x);
+                                            wire.pos[0].y = Math.round(wire.pos[0].y);
+                                        }
+                                    }
                                 }
                             }
 
@@ -1033,14 +1099,18 @@ c.onmouseup = function(e) {
                         }
                     }
 
-                    const wire = port.connection;
-                    if(wire) {
-                        if(port.type == "input") {
-                            wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
-                            wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
-                        } else {
-                            wire.pos[0].x = Math.round(wire.pos[0].x);
-                            wire.pos[0].y = Math.round(wire.pos[0].y);
+                    const cons = port.connection;
+                    if (cons) {
+                        for (let wire of cons) {
+                            if(wire) {
+                                if(port.type == "input") {
+                                    wire.pos.slice(-1)[0].x = Math.round(wire.pos.slice(-1)[0].x);
+                                    wire.pos.slice(-1)[0].y = Math.round(wire.pos.slice(-1)[0].y);
+                                } else {
+                                    wire.pos[0].x = Math.round(wire.pos[0].x);
+                                    wire.pos[0].y = Math.round(wire.pos[0].y);
+                                }
+                            }
                         }
                     }
 
@@ -1092,11 +1162,13 @@ c.onmouseup = function(e) {
                 if(wires.length > 1) {
                     const wire1PosIndex = wires[0].pos.findIndex(pos => pos.x == mouse.grid.x && pos.y == mouse.grid.y);
                     if(wire1PosIndex) {
-                        const wire1Dx = wires[0].pos[wire1PosIndex].x - wires[0].pos[wire1PosIndex + 1].x;
-                        if (wire1Dx != 0) {
-                            const tmp = wires[0];
-                            wires[0] = wires[1];
-                            wires[1] = tmp;
+                        if (wires[0].pos[wire1PosIndex]) {
+                            const wire1Dx = wires[0].pos[wire1PosIndex].x - wires[0].pos[wire1PosIndex + 1].x;
+                            if (wire1Dx != 0) {
+                                const tmp = wires[0];
+                                wires[0] = wires[1];
+                                wires[1] = tmp;
+                            }
                         }
                     }
 
@@ -1109,7 +1181,6 @@ c.onmouseup = function(e) {
                     // TODO: meer dan 2
                     if(wires.length > 2) dialog.warning(wires.length + " wires found. Please don't. Get out (menuutje voor Teun)");
                     if(wires[0].input.includes(wires[1]) && wires[0].output.includes(wires[1])) {
-                        console.log(1);
                         const inputIndex = wires[0].input.indexOf(wires[1]);
                         if(inputIndex > -1) wires[0].input.splice(inputIndex,1);
                         const outputIndex = wires[1].output.indexOf(wires[0]);
@@ -1120,7 +1191,6 @@ c.onmouseup = function(e) {
                             intersection.type = 1;
                         }
                     } else if(wires[1].input.includes(wires[0])) {
-                        console.log(2);
                         const inputIndex = wires[1].input.indexOf(wires[0]);
                         if(inputIndex > -1) wires[1].input.splice(inputIndex,1);
                         const outputIndex = wires[0].output.indexOf(wires[1]);
@@ -1133,7 +1203,6 @@ c.onmouseup = function(e) {
                             intersection.type = 2;
                         }
                     } else if(wires[1].output.includes(wires[0])) {
-                        console.log(3);
                         const inputIndex = wires[0].input.indexOf(wires[1]);
                         if(inputIndex > -1) wires[0].input.splice(inputIndex,1);
                         const outputIndex = wires[1].output.indexOf(wires[0]);
@@ -1144,7 +1213,6 @@ c.onmouseup = function(e) {
                             wires[1].intersections.splice(intersection,1);
                         }
                     } else {
-                        console.log(4);
                         connectWires(wires[0],wires[1]);
                         connectWires(wires[1],wires[0]);
 

--- a/app/js/componentUpdates.js
+++ b/app/js/componentUpdates.js
@@ -5,16 +5,22 @@ let ticksPerSecond = 0;
 
 let pauseSimulation = false;
 let updates;
+let maxUpdatesInitial = 10000;
+let maxUpdates = maxUpdatesInitial;
 
 
 function tick() {
     const start = new Date;
     updates = 0;
 
-    while(updateQueue.length > 0 && updates < 10000 && !pauseSimulation) {
+    while(updateQueue.length > 0 && updates < maxUpdates && !pauseSimulation) {
         updateQueue.splice(0,1)[0]();
         ++updates;
     }
+
+    // randomize max updates, so that flickering wires will flicker on screen as their value will be different each tick
+    // due to different max updates
+    maxUpdates = maxUpdatesInitial + Math.floor(Math.random() * Math.floor(100)) - 50;
 
     ticksPerSecond = 1000 / (new Date - lastTick);
     lastTick = new Date;

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -248,14 +248,16 @@ function removeWire(wire, undoable = false, sendToSocket = true) {
     }
 
     for(let i = 0; i < wire.output.length; ++i) {
-        const index = wire.output[i].input.indexOf(wire);
-        if(index > -1) {
-            wire.output[i].input.splice(index,1);
-            if(!wire.output[i].from) {
-                const removed = removeWire(wire.output[i]);
-                removedWires.push(...removed);
-            } else {
-                wire.output[i].update(0, this);
+        if (wire.output[i]) {
+            const index = wire.output[i].input.indexOf(wire);
+            if(index > -1) {
+                wire.output[i].input.splice(index,1);
+                if(!wire.output[i].from) {
+                    const removed = removeWire(wire.output[i]);
+                    removedWires.push(...removed);
+                } else {
+                    wire.output[i].update(0, this);
+                }
             }
         }
     }

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -1367,30 +1367,38 @@ function cloneComponent(component, dx = 0, dy = 0) {
         clone.width = component.width;
 
         for(let i = 0; i < component.input.length; ++i) {
-            clone.input[i].name = component.input[i].name;
-            clone.input[i].value = component.input[i].value;
-            clone.input[i].pos = Object.assign({},component.input[i].pos);
+            if (component.input[i]) {
+                clone.input[i].name = component.input[i].name;
+                clone.input[i].value = component.input[i].value;
+                clone.input[i].pos = Object.assign({},component.input[i].pos);
+            }
         }
 
         for(let i = 0; i < component.output.length; ++i) {
-            clone.output[i].name = component.output[i].name;
-            clone.output[i].value = component.output[i].value;
-            clone.output[i].pos = Object.assign({},component.output[i].pos);
+            if (component.output[i]) {
+                clone.output[i].name = component.output[i].name;
+                clone.output[i].value = component.output[i].value;
+                clone.output[i].pos = Object.assign({},component.output[i].pos);
+            }
         }
     } else {
         clone.input = [];
         for(let i = 0; i < component.input.length; ++i) {
-            const port = clone.addInputPort();
-            port.name = component.input[i].name;
-            port.value = component.input[i].value;
-            port.pos = Object.assign({},component.input[i].pos);
+            if (component.input[i]) {
+                const port = clone.addInputPort();
+                port.name = component.input[i].name;
+                port.value = component.input[i].value;
+                port.pos = Object.assign({},component.input[i].pos);
+            }
         }
         clone.output = [];
         for(let i = 0; i < component.output.length; ++i) {
-            const port = clone.addOutputPort();
-            port.name = component.output[i].name;
-            port.value = component.output[i].value;
-            port.pos = Object.assign({},component.output[i].pos);
+            if (component.output[i]) {
+                const port = clone.addOutputPort();
+                port.name = component.output[i].name;
+                port.value = component.output[i].value;
+                port.pos = Object.assign({},component.output[i].pos);
+            }
         }
     }
     return clone;

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3398,7 +3398,7 @@ class Wire {
 
         for (let i = 0; i < this.input.length; ++i) {
             const inp = this.input[i];
-            if (inp.value == 1) {
+            if (inp && inp.value == 1) {
                 if (inp.getNewValue) {
                     value = Math.max(value, inp.getNewValue());
                 } else {
@@ -3409,7 +3409,7 @@ class Wire {
 
         for (let i = 0; i < this.output.length; ++i) {
             const inp = this.output[i];
-            if (inp.value == 1) {
+            if (inp && inp.value == 1) {
                 if (inp.getNewValue) {
                     value = Math.max(value, inp.getNewValue());
                 } else {
@@ -3440,7 +3440,7 @@ class Wire {
 
         for(let i = 0; i < this.output.length; ++i) {
             const wire = this.output[i];
-            if(wire != from) {
+            if(wire && wire != from) {
                 if (wire.constructor.name == this.constructor.name) {
                     if (wire.value != this.value) {
                         wire.update(this.value, this);
@@ -3453,7 +3453,7 @@ class Wire {
 
         for(let i = 0; i < this.input.length; ++i) {
             const wire = this.input[i];
-            if(wire != from && wire.value != this.value) {
+            if(wire && wire != from && wire.value != this.value) {
                 if (wire.constructor.name == this.constructor.name) {
                     if (wire.value != this.value) {
                         wire.update(this.value, this);

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3438,6 +3438,11 @@ class Wire {
             from = null;
         }
 
+        if(this.to && this.to.value != this.value) {
+            this.to.value = this.value;
+            this.to.component && updateQueue.push(this.to.component.update.bind(this.to.component));
+        }
+
         for(let i = 0; i < this.output.length; ++i) {
             const wire = this.output[i];
             if(wire && wire != from) {
@@ -3462,11 +3467,6 @@ class Wire {
                     wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
                 }
             }
-        }
-
-        if(this.to && this.to.value != this.value) {
-            this.to.value = this.value;
-            this.to.component && updateQueue.push(this.to.component.update.bind(this.to.component));
         }
     }
 

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -2055,6 +2055,7 @@ class TimerStart extends Component {
         console.time();
         timerStart = new Date;
 
+        this.updateInputPorts();
         this.function();
 
         this.output[0].value = this.value;
@@ -2082,6 +2083,7 @@ class TimerEnd extends Component {
         console.timeEnd();
         boolrConsole.log(this.name + ": " + (new Date - timerStart) + " ms");
 
+        this.updateInputPorts();
         this.function();
 
         this.input[0].value == 1 && (this.value = 1);
@@ -2205,6 +2207,7 @@ class Delay extends Component {
         if(settings.showComponentUpdates) this.highlight(250);
 
         this.lastUpdate = new Date;
+        this.updateInputPorts();
 
         const value = this.input[0].value;
         setTimeout(() => updateQueue.push(
@@ -2704,7 +2707,7 @@ class Display extends Component {
     }
 
     update() {
-
+        this.updateInputPorts();
     }
 
     draw() {
@@ -2996,6 +2999,7 @@ class Display extends Component {
 //         if(settings.showComponentUpdates) this.highlight(250);
 //
 //         // Update output ports
+//         this.updateInputPorts();
 //         this.function();
 //
 //         const port = this.output[0];
@@ -3128,6 +3132,7 @@ class Custom extends Component {
     update() {
         // Highlight
         if(settings.showComponentUpdates) this.highlight(250);
+        this.updateInputPorts();
 
         this.function();
     }

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3385,8 +3385,12 @@ class Wire {
         this.color = color;
     }
 
-    update(value,from) {
-        let initial_value = value;
+    getNewValue() {
+        // check value of inputs and outpus if value of this wire would be zero
+        // in this way we can ensure no self-powering or loop powering
+        let value = 0;
+        let old_value = this.value;
+        this.value = 0;
 
         if(this.from && this.from.value == 1) {
             value = 1;
@@ -3394,7 +3398,36 @@ class Wire {
 
         for (let i = 0; i < this.input.length; ++i) {
             const inp = this.input[i];
-            value = Math.max(value, inp.value);
+            if (inp.value == 1) {
+                if (inp.getNewValue) {
+                    value = Math.max(value, inp.getNewValue());
+                } else {
+                    value = inp.value;
+                }
+            }
+        }
+
+        for (let i = 0; i < this.output.length; ++i) {
+            const inp = this.output[i];
+            if (inp.value == 1) {
+                if (inp.getNewValue) {
+                    value = Math.max(value, inp.getNewValue());
+                } else {
+                    value = inp.value;
+                }
+            }
+        }
+
+        this.value = old_value;
+
+        return value;
+    }
+
+    update(value,from) {
+        let initial_value = value;
+
+        if (value == 0 && this.value == 1) {
+             value = this.getNewValue();
         }
 
         if(this.value == value && initial_value == value) return;

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3400,14 +3400,14 @@ class Wire {
 
         for(let i = 0; i < this.output.length; ++i) {
             const wire = this.output[i];
-            if(wire != from) {
+            if(wire != from && wire.value != this.value) {
                 wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
             }
         }
 
         for(let i = 0; i < this.input.length; ++i) {
             const wire = this.input[i];
-            if(wire != from) {
+            if(wire != from && wire.value != this.value) {
                 wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
             }
         }

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3400,15 +3400,27 @@ class Wire {
 
         for(let i = 0; i < this.output.length; ++i) {
             const wire = this.output[i];
-            if(wire != from && wire.value != this.value) {
-                wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
+            if(wire != from) {
+                if (wire.constructor.name == this.constructor.name) {
+                    if (wire.value != this.value) {
+                        wire.update(this.value, this);
+                    }
+                } else {
+                    wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
+                }
             }
         }
 
         for(let i = 0; i < this.input.length; ++i) {
             const wire = this.input[i];
             if(wire != from && wire.value != this.value) {
-                wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
+                if (wire.constructor.name == this.constructor.name) {
+                    if (wire.value != this.value) {
+                        wire.update(this.value, this);
+                    }
+                } else {
+                    wire.update && updateQueue.push(wire.update.bind(wire,this.value,this));
+                }
             }
         }
 

--- a/app/js/components.js
+++ b/app/js/components.js
@@ -3390,6 +3390,11 @@ class Wire {
             value = 1;
         }
 
+        for (let i = 0; i < this.input.length; ++i) {
+            const inp = this.input[i];
+            value = Math.max(value, inp.value);
+        }
+
         if(this.value == value && initial_value == value) return;
         
         this.value = value;

--- a/app/js/contextmenu2.js
+++ b/app/js/contextmenu2.js
@@ -300,7 +300,7 @@ createContextMenuOption(
     "Delete",
     function() {
         const component = findComponentByPos(...contextMenu.getPos());
-        removeComponent(component);
+        removeComponent(component, true);
     },
     function() {
         const component = findComponentByPos(...contextMenu.getPos());
@@ -313,7 +313,7 @@ createContextMenuOption(
     "delete",
     "Delete",
     function() {
-        removeSelection(selecting.components,selecting.wires);
+        removeSelection(selecting.components,selecting.wires, true);
     },
     function() {
         return selecting;

--- a/app/js/dialogs.js
+++ b/app/js/dialogs.js
@@ -203,32 +203,42 @@ dialog.connections = function(component) {
 
     const input = document.createElement("ul");
     for(let i = 0; i < component.input.length; ++i) {
-        const wire = component.input[i].connection;
-        wire && (function getInputs(wire) {
-            if(wire.from) {
-                const li = document.createElement("li");
-                li.innerHTML = wire.from.component.name;
-                input.appendChild(li);
+        const cons = component.input[i].connection;
+
+        if (cons) {
+            for (let wire of cons) {
+                wire && (function getInputs(wire) {
+                    if(wire.from) {
+                        const li = document.createElement("li");
+                        li.innerHTML = wire.from.component.name;
+                        input.appendChild(li);
+                    }
+                    for(let i = 0; i < wire.input.length; ++i) {
+                        getInputs(wire.input[i]);
+                    }
+                })(wire);
             }
-            for(let i = 0; i < wire.input.length; ++i) {
-                getInputs(wire.input[i]);
-            }
-        })(wire);
+        }
     }
 
     const output = document.createElement("ul");
     for(let i = 0; i < component.output.length; ++i) {
-        const wire = component.output[i].connection;
-        wire && (function getOutputs(wire) {
-            if(wire.to) {
-                const li = document.createElement("li");
-                li.innerHTML = wire.to.component.name;
-                output.appendChild(li);
+        const cons = component.output[i].connection;
+
+        if (cons) {
+            for (let wire of cons) {
+                wire && (function getOutputs(wire) {
+                    if(wire.to) {
+                        const li = document.createElement("li");
+                        li.innerHTML = wire.to.component.name;
+                        output.appendChild(li);
+                    }
+                    for(let i = 0; i < wire.output.length; ++i) {
+                        getOutputs(wire.output[i]);
+                    }
+                })(wire);
             }
-            for(let i = 0; i < wire.output.length; ++i) {
-                getOutputs(wire.output[i]);
-            }
-        })(wire);
+        }
     }
 
     const connections = input.children.length + output.children.length;
@@ -490,10 +500,20 @@ dialog.editPort = function(port) {
     dialog.container.appendChild(position);
 
     const deleteConnection = document.createElement("button");
-    deleteConnection.innerHTML = "Delete connection";
+    if (port.connection && port.connection.length > 1) { 
+        deleteConnection.innerHTML = "Delete connections";
+    } else {
+        console.log(port.connection)
+        deleteConnection.innerHTML = "Delete connection";
+    }
     deleteConnection.style.background = "#600";
     deleteConnection.onclick = () => {
-        removeWire(port.connection);
+        if (port.connection) {
+            while (port.connection.length) {
+                let wire = port.connection[0];
+                removeWire(wire);
+            }
+        }
     }
     dialog.container.appendChild(deleteConnection);
 

--- a/app/js/localStorage2.js
+++ b/app/js/localStorage2.js
@@ -137,7 +137,6 @@ function stringify(components = [], wires = [], selection) {
 
         data.input = [];
         for(let i = 0; i < component.input.length; ++i) {
-            console.log(component.input[i]);
             data.input[i] = {
                 id: component.input[i].id,
                 name: component.input[i].name,

--- a/app/js/localStorage2.js
+++ b/app/js/localStorage2.js
@@ -137,6 +137,7 @@ function stringify(components = [], wires = [], selection) {
 
         data.input = [];
         for(let i = 0; i < component.input.length; ++i) {
+            console.log(component.input[i]);
             data.input[i] = {
                 id: component.input[i].id,
                 name: component.input[i].name,
@@ -372,11 +373,21 @@ function parse(data) {
         }
 
         if(wire.to) {
-            wire.to.connection = wire;
+            if (!wire.to.connection) {
+                wire.to.connection = [];
+            }
+            if (wire.to.connection.indexOf(wire) == -1) {
+                wire.to.connection.push(wire);
+            }
         }
 
         if(wire.from) {
-            wire.from.connection = wire;
+            if (!wire.from.connection) {
+                wire.from.connection = [];
+            }
+            if (wire.from.connection.indexOf(wire) == -1) {
+                wire.from.connection.push(wire);
+            }
         }
     }
 

--- a/app/js/stringifier.js
+++ b/app/js/stringifier.js
@@ -87,11 +87,13 @@ function parse_old(string,dx,dy,select) {
 
         const from = result[connection[0]];
         const to = result[connection[1]];
-        const wire = result[connection[2]];
+        const cons = result[connection[2]];
 
-        wire.from = from;
-        wire.to = to;
-        connect(from,to,wire);
+        for (let wire of cons) {
+            wire.from = from;
+            wire.to = to;
+            connect(from,to,wire);
+        }
     }
 
     if(select) {

--- a/app/js/tips.js
+++ b/app/js/tips.js
@@ -13,18 +13,18 @@ for(let i in tips) {
             this.style.opacity = .9;
 
             (function animate() {
-                tips[i].style.left =
+                tips[i].style.left = 20;/*
                     Math.max(
                         Math.min(
                             mouse.screen.x - tips[i].clientWidth / 2,
                             c.width - tips[i].clientWidth),
                         0
-                    );
-                tips[i].style.top =
+                    );*/
+                tips[i].style.top = 20; /*
                     Math.max(
                         mouse.screen.y - tips[i].clientHeight - 20,
                         0
-                    );
+                    );*/
 
                 if(tips[i].style.display == "block") requestAnimationFrame(animate);
             })();


### PR DESCRIPTION
This pull request fixes problems connecting wires to wires

How to reproduce:
- connect input 1 to output 1 
- connect input 0 to output 0
- connect wire connecting i/o 1 to i/o 0 (from top to bottom)
- activate inputs 0 and 1
- deactivate input 1

<img width="400" alt="Screenshot 2020-09-06 at 09 34 31" src="https://user-images.githubusercontent.com/12446853/92319756-4d06c680-f024-11ea-861e-4f757a9f9b6d.png">

When deactivating Input#1 I would expect no wires to change value, but upper part of the circuit goes off, while the lower stays on:
<img width="400" alt="Screenshot 2020-09-06 at 09 35 34" src="https://user-images.githubusercontent.com/12446853/92319773-7293d000-f024-11ea-9304-c9f2d9b53636.png">
But disabling Input#2 works as expected

Other fixed problems:
1. If I try to add wire with opposite direction and disable both Input#1 and Input#2, then all wires will still be on  due to loop powering of two wires of opposite direction
2. Removing wires does not trigger update
3. Undoing wires removal does not trigger update
4. Removing selection and undoing does not display wire but adds it
5. When multiple wires connected to one port only the last one is really connected, so when dragging the component/port earlier wires are not moving
6. When multiple wire connected to one port and one of them goes off it will turn off the port no matter what other wires' value is
7. When connecting wire to port that already has wire, than first wire will be connected to the second wire, not the port